### PR TITLE
chore: upgrade cyclist to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "author": "Mathias Buus Madsen <mathiasbuus@gmail.com>",
   "dependencies": {
-    "cyclist": "~0.2.2",
+    "cyclist": "^1.0.1",
     "inherits": "^2.0.3",
     "readable-stream": "^2.1.5"
   }


### PR DESCRIPTION
cyclist 0.2.2 neither has a license specified in its package.json nor does it
package a license. This upgrade ensures that all dependencies of
parallel-transform are properly licensed. All updates between the two versions
should be non-breaking.