### PR TITLE
Use _final instead of _flush

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ var ParallelTransform = function(maxParallel, opts, ontransform) {
 	this._maxParallel = maxParallel;
 	this._ontransform = ontransform;
 	this._destroyed = false;
-	this._flushed = false;
+	this._finishing = false;
 	this._ordered = opts.ordered !== false;
 	this._buffer = this._ordered ? cyclist(maxParallel) : [];
 	this._top = 0;
@@ -66,9 +66,9 @@ ParallelTransform.prototype._transform = function(chunk, enc, callback) {
 	this._ondrain = callback;
 };
 
-ParallelTransform.prototype._flush = function(callback) {
-	this._flushed = true;
-	this._ondrain = callback;
+ParallelTransform.prototype._final = function(callback) {
+	this._finishing = true;
+	this.ondrain = callback;
 	this._drain();
 };
 
@@ -99,7 +99,7 @@ ParallelTransform.prototype._drain = function() {
 
 ParallelTransform.prototype._drained = function() {
 	var diff = this._top - this._bottom;
-	return this._flushed ? !diff : diff < this._maxParallel;
+	return this._finishing ? !diff : diff < this._maxParallel;
 };
 
 module.exports = ParallelTransform;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "dependencies": {
     "cyclist": "~0.2.2",
     "inherits": "^2.0.3",
-    "readable-stream": "^2.1.5"
+    "readable-stream": "^2.3.6"
   }
 }


### PR DESCRIPTION
Now that node 8 and `readable-stream` include the `_final` method, we should use that when closing down instead of `_flush` to make sure all processing is done before `'finish'` event fires. 

The only change should be that the `Writable` side of the transform does not close after everything has been passed to transform function but after everything has been processed, [as should happen according to node docs](https://nodejs.org/api/stream.html#stream_events_finish_and_end).

Fixes #4 