### PR TITLE
readable-stream@3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "dependencies": {
     "cyclist": "~0.2.2",
     "inherits": "^2.0.3",
-    "readable-stream": "^2.1.5"
+    "readable-stream": "^3.0.2"
   }
 }


### PR DESCRIPTION
This PR updates readable-stream to 3.0.2 to work on fixing an NPM bug. See npm/cli#59